### PR TITLE
ci: Add Zizmor Checking

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       # Lint and Format everything except Rust/Python
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v7.2.1
@@ -41,3 +42,28 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_PYTHON_RUFF: false
           VALIDATE_PYTHON_PYINK: false
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflow configuration file `.github/workflows/code-checks.yml`. The changes introduce a new job for checking GitHub Actions with zizmor and make a small modification to the existing job configuration.

New job addition and configuration update:

* Added a new job `run-zizmor` to check GitHub Actions with zizmor. This job includes steps for checking out the repository, installing the latest version of `uv`, running `zizmor`, and uploading the SARIF file.
* Updated the existing checkout step to disable credential persistence by setting `persist-credentials` to `false`.

Fixes #21 
