### PR TITLE
chore: Add Dependabot for Cargo/Rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,27 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - ".github/actions/setup-dependencies"
-      - ".github/actions/local"
     commit-message:
       prefix: "deps(github-actions)"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "cargo"
+    directories:
+      - "/"
+    commit-message:
+      prefix: "deps(rust)"
     schedule:
       interval: "weekly"
       day: "saturday"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github/dependabot.yml` file to update the configuration for dependency updates. The most important changes include removing unnecessary directories for GitHub Actions updates and adding a new configuration for Rust dependencies.

Updates to GitHub Actions configuration:

* Removed unnecessary directories `.github/actions/setup-dependencies` and `.github/actions/local` from the `github-actions` package-ecosystem.

Addition of Rust dependencies configuration:

* Added a new `cargo` package-ecosystem configuration for Rust dependencies, including a weekly update schedule on Saturdays at 01:00, targeting the `main` branch, and grouping updates under `github-actions`.

Fixes #41 
