### PR TITLE
Generate a crate to read pyproject and uv scripts, find latest version and upgrade all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+toml = "0.5"
+reqwest = { version = "0.11", features = ["blocking"] }
+semver = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,34 @@
+use std::fs;
+use std::collections::HashMap;
+use toml::Value;
+use reqwest::blocking::get;
+use semver::Version;
+
+fn read_pyproject_toml() -> HashMap<String, String> {
+    let content = fs::read_to_string("pyproject.toml").expect("Failed to read pyproject.toml");
+    let value: Value = content.parse().expect("Failed to parse pyproject.toml");
+    let dependencies = value["tool"]["poetry"]["dependencies"].as_table().expect("Failed to get dependencies");
+    dependencies.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap().to_string())).collect()
+}
+
+fn find_latest_version(dependency: &str) -> String {
+    let url = format!("https://pypi.org/pypi/{}/json", dependency);
+    let response = get(&url).expect("Failed to fetch dependency info");
+    let json: Value = response.json().expect("Failed to parse dependency info");
+    json["info"]["version"].as_str().unwrap().to_string()
+}
+
+fn upgrade_dependencies(dependencies: &mut HashMap<String, String>) {
+    for (name, version) in dependencies.iter_mut() {
+        let latest_version = find_latest_version(name);
+        if Version::parse(&latest_version).unwrap() > Version::parse(version).unwrap() {
+            *version = latest_version;
+        }
+    }
+}
+
 fn main() {
-    println!("Hello, world!");
+    let mut dependencies = read_pyproject_toml();
+    upgrade_dependencies(&mut dependencies);
+    println!("Updated dependencies: {:?}", dependencies);
 }


### PR DESCRIPTION
Related to #57

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JackPlowman/depup/pull/59?shareId=c4060860-326d-45fa-997a-7b588e75584a).